### PR TITLE
Support time 1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,7 @@
   - Imported from private codebase.
 # Version 0.1.0.1
   - Fix build depends to include time 1.5
-# Version 0.1.1.2
+# Version 0.1.0.2
   - time and base version bumps
+# Version 0.1.0.3
+  - time version 1.8

--- a/timezone-olson-th.cabal
+++ b/timezone-olson-th.cabal
@@ -39,7 +39,7 @@ library
   build-depends:       base >=4.7 && <4.10, 
                        timezone-olson >=0.1 && <0.2, 
                        timezone-series >=0.1 && <0.2, 
-                       time >=1.4 && <1.7, 
+                       time >=1.4 && <1.9, 
                        template-haskell
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/timezone-olson-th.cabal
+++ b/timezone-olson-th.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                timezone-olson-th
-version:             0.1.0.2
+version:             0.1.0.3
 synopsis:            Load TimeZoneSeries from an Olson file at compile time.
 description:         
   Template Haskell to load a TimeZoneSeries from an Olson file at compile time.


### PR DESCRIPTION
The ygale/timezone-series and ygale/timezone-olson libraries have been updated to support time 1.8.