### PR TITLE
Allow time 1.10, 1.11, 1.12, 1.13

### DIFF
--- a/timezone-olson-th.cabal
+++ b/timezone-olson-th.cabal
@@ -39,7 +39,7 @@ library
   build-depends:       base >=3.0 && <5.0, 
                        timezone-olson >=0.1 && <0.2, 
                        timezone-series >=0.1 && <0.2, 
-                       time >=1.4 && <1.10,
+                       time >=1.4 && <1.14,
                        template-haskell
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
All of these time releases are already out, and it doesn't look like it breaks with at least version 1.11 which I tested with. ~~I am not sure how to test with the other versions.~~ Tested using `cabal build --constraint='time==1.10'` for all versions up to 1.13. 1.13 was withdrawn so it doesn't build, but that is expected. This way, the next time it is bumped, we will know that 1.13 was already tested.