### PR TITLE
Allow timezone-olson v0.2 series

### DIFF
--- a/timezone-olson-th.cabal
+++ b/timezone-olson-th.cabal
@@ -37,7 +37,7 @@ library
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base >=3.0 && <5.0, 
-                       timezone-olson >=0.1 && <0.2, 
+                       timezone-olson >=0.1 && <0.3,
                        timezone-series >=0.1 && <0.2, 
                        time >=1.4 && <1.14,
                        template-haskell


### PR DESCRIPTION
Tested using the following stanza in the cabal file:

    executable test
      main-is: Main.hs
      hs-source-dirs: .
      build-depends:
        base,
        timezone-olson,
        timezone-series,
        timezone-olson-th

With the following Main.hs:

    {-# LANGUAGE TemplateHaskell #-}
    
    import Data.Time.LocalTime.TimeZone.Series
    import Data.Time.LocalTime.TimeZone.Olson.TH
    
    myTimeZoneSeries :: TimeZoneSeries
    myTimeZoneSeries = $(loadTZFile "/usr/share/zoneinfo/Europe/Stockholm")
    
    main :: IO ()
    main = do
      print myTimeZoneSeries

Then `cabal run --constraint="timezone-olson>=0.2"` compiles and prints "CET" as expected.
